### PR TITLE
Fix Image size not supported Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Obtain some basic information about a movie in json format
 ```
 - Run the script
 
+## Requirements
+
+- cURL
+- xdg-open (View the Movie Poster)
+
+```
+sudo apt-get install xdg-utils
+```
+
+- jq 
+
+```
+sudo apt install jq
+```
+
 ## How to use it
 ```
 Usage :  tmdb.sh [options] title

--- a/README.md
+++ b/README.md
@@ -3,15 +3,6 @@
 
 Obtain some basic information about a movie in json format
 
-## Setup
-- Go to The Movie DB website and create an account
-- Obtain an API key by following the [instructions](https://www.themoviedb.org/faq/api)
-- Copy your API key to the correct place in the tmdb.sh script 
-```shell
-    APIKEY="your api key"
-```
-- Run the script
-
 ## Requirements
 
 - cURL
@@ -26,6 +17,16 @@ sudo apt-get install xdg-utils
 ```
 sudo apt install jq
 ```
+
+## Setup
+- Go to The Movie DB website and create an account
+- Obtain an API key by following the [instructions](https://www.themoviedb.org/faq/api)
+- Copy your API key to the correct place in the tmdb.sh script 
+```shell
+    APIKEY="your api key"
+```
+- Run the script
+
 
 ## How to use it
 ```
@@ -75,6 +76,7 @@ Usage :  tmdb.sh [options] title
         ]
     }
 ```
+
 
 
 ## License

--- a/tmdb.sh
+++ b/tmdb.sh
@@ -5,8 +5,8 @@
 #   author:    Miroslav Vidovic
 #   file:      tmdb.sh
 #   created:   06.10.2016.-13:29:29
-#   revision:  20.07.2017.
-#   version:   1.1
+#   revision:  26.01.2018.
+#   version:   1.2
 # -----------------------------------------------------------------------------
 # Requirements:
 #   curl, xdg-open, jq
@@ -43,7 +43,7 @@ get_movie_info(){
 }
 
 show_poster(){
- xdg-open http://image.tmdb.org/t/p/w1000/"$1"
+ xdg-open https://image.tmdb.org/t/p/w500"$1"
 }
 
 main(){


### PR DESCRIPTION
Fix Image size not supported Error & Not Found Error

Update `xdg-open` URL

````
show_poster(){
 xdg-open http://image.tmdb.org/t/p/w1000/"$1"
}
````

to

```
show_poster(){
 xdg-open https://image.tmdb.org/t/p/w500"$1"
}
```
Now it will open movie Posters in Browsers without errors

- Update Readme File
